### PR TITLE
Add realtime service for form updates

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { RealtimeService } from './services/realtime.service';
 import { RouterOutlet } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { PersonalDataTabComponent } from './components/personal-data-tab/personal-data-tab.component';
@@ -30,6 +31,16 @@ export class AppComponent {
     unfallDetails: {} as UnfallDetails,
     fahrzeugDaten: {} as FahrzeugDaten
   };
+
+  constructor(private realtime: RealtimeService) {
+    this.realtime.formUpdates$.subscribe(update => {
+      this.formData = {
+        personalData: { ...this.formData.personalData, ...(update.personalData || {}) },
+        unfallDetails: { ...this.formData.unfallDetails, ...(update.unfallDetails || {}) },
+        fahrzeugDaten: { ...this.formData.fahrzeugDaten, ...(update.fahrzeugDaten || {}) }
+      };
+    });
+  }
 
   setActiveTab(index: number) {
     this.activeTab = index;

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,7 +3,8 @@ import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
+import { RealtimeService } from './services/realtime.service';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideClientHydration()]
+  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideClientHydration(), RealtimeService]
 };

--- a/src/app/services/realtime.service.ts
+++ b/src/app/services/realtime.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, NgZone } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+import { UnfallFormData } from '../accident-data/accident-data.module';
+
+@Injectable()
+export class RealtimeService {
+  private socket?: WebSocket;
+  private formUpdatesSubject = new Subject<Partial<UnfallFormData>>();
+
+  formUpdates$: Observable<Partial<UnfallFormData>> = this.formUpdatesSubject.asObservable();
+
+  constructor(private zone: NgZone) {}
+
+  startSession(apiKey: string) {
+    if (this.socket) {
+      this.socket.close();
+    }
+    const url = 'wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview';
+    this.socket = new WebSocket(url, [
+      'realtime',
+      `openai-insecure-api-key.${apiKey}`,
+      'openai-beta.realtime=v1',
+    ]);
+    this.socket.onmessage = (event) => this.handleMessage(event);
+    this.socket.onerror = (err) => console.error('Realtime session error', err);
+  }
+
+  private handleMessage(event: MessageEvent) {
+    try {
+      const message = JSON.parse(event.data);
+      if (message.type === 'form_update' && message.data) {
+        this.zone.run(() => this.formUpdatesSubject.next(message.data));
+      }
+    } catch (error) {
+      console.error('Failed to handle message', error);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add RealtimeService with WebSocket session and message handling
- subscribe in AppComponent to apply realtime form updates
- register RealtimeService in application providers

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68b31b137978832788796daf2d35a64f