### PR TITLE
Add assistant toggle button with RealtimeService control

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -6,9 +6,19 @@
           <p class="text-gray-600">Erfassen Sie alle relevanten Daten zu Ihrem Verkehrsunfall</p>
         </header>
 
+        <div class="text-center mb-4">
+          <button
+            class="btn text-white"
+            [ngClass]="assistantActive ? 'bg-green-500' : 'bg-blue-500'"
+            (click)="assistant()"
+          >
+            Assistent starten
+          </button>
+        </div>
+
         <div class="bg-white rounded-xl shadow-lg overflow-hidden">
           <nav class="tab-nav">
-            <button 
+            <button
               *ngFor="let tab of tabs; let i = index"
               class="tab-button"
               [class.active]="activeTab === i"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { FahrzeugDatenTabComponent } from './components/fahrzeug-daten-tab/fahrz
 import { UnfallDetailsTabComponent } from './components/unfall-details-tab/unfall-details-tab.component';
 import { SummaryTabComponent } from './components/summary-tab/summary-tab.component';
 import { FahrzeugDaten, PersonalData, UnfallDetails, UnfallFormData } from './accident-data/accident-data.module';
+import { RealtimeService } from './realtime.service';
 
 @Component({
   selector: 'app-root',
@@ -17,6 +18,7 @@ import { FahrzeugDaten, PersonalData, UnfallDetails, UnfallFormData } from './ac
 export class AppComponent {
   title = 'accident-report';
   activeTab = 0;
+  assistantActive = false;
 
   tabs = [
     { label: 'Persönliche Daten', icon: '👤' },
@@ -30,6 +32,8 @@ export class AppComponent {
     unfallDetails: {} as UnfallDetails,
     fahrzeugDaten: {} as FahrzeugDaten
   };
+
+  constructor(private realtimeService: RealtimeService) {}
 
   setActiveTab(index: number) {
     this.activeTab = index;
@@ -57,6 +61,16 @@ export class AppComponent {
 
   updateFahrzeugDaten(data: FahrzeugDaten) {
     this.formData.fahrzeugDaten = data;
+  }
+
+  assistant() {
+    if (!this.assistantActive) {
+      this.realtimeService.startSession();
+      this.assistantActive = true;
+    } else {
+      this.realtimeService.stopSession();
+      this.assistantActive = false;
+    }
   }
 }
 

--- a/src/app/realtime.service.ts
+++ b/src/app/realtime.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RealtimeService {
+  startSession(): void {
+    console.log('Realtime session started');
+  }
+
+  stopSession(): void {
+    console.log('Realtime session stopped');
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add "Assistent starten" button to the main page with dynamic color indicating session state
- Introduce RealtimeService and assistant() method to start/stop sessions

## Testing
- `CHROME_BIN=chromium-browser npm test -- --watch=false` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b31bc2052883279061607670376ea7