### PR TITLE
feat: implement WebRTC realtime service

### DIFF
--- a/src/app/services/realtime.service.ts
+++ b/src/app/services/realtime.service.ts
@@ -4,39 +4,95 @@ import { UnfallFormData } from '../accident-data/accident-data.module';
 
 @Injectable()
 export class RealtimeService {
-  private socket?: WebSocket;
-  private formUpdatesSubject = new Subject<Partial<UnfallFormData>>();
+  // Aktueller WebRTC-Verbindungskanal
+  private pc?: RTCPeerConnection;
+  // Datenkanal zum Senden und Empfangen von Ereignissen
+  private dc?: RTCDataChannel;
+  // Lokaler Audiostream (Mikrofon)
+  private ms?: MediaStream;
+  // Verstecktes Audioelement zur Wiedergabe des Remote-Audios
+  private audioEl?: HTMLAudioElement;
 
+  // Subjekt für Formularaktualisierungen
+  private formUpdatesSubject = new Subject<Partial<UnfallFormData>>();
   formUpdates$: Observable<Partial<UnfallFormData>> = this.formUpdatesSubject.asObservable();
+
+  // Basis-URL und Model für den Realtime-Endpunkt
+  private baseUrl = 'https://api.openai.com/v1/realtime';
+  private model = 'gpt-4o-realtime';
 
   constructor(private zone: NgZone) {}
 
-  startSession(apiKey: string) {
-    if (this.socket) {
-      this.socket.close();
+  /**
+   * Startet eine neue Realtime-Sitzung über WebRTC.
+   * Stellt eine Verbindung zum OpenAI Realtime-Endpoint her
+   * und richtet Audio- sowie Datenkanäle ein.
+   */
+  async startSession(apiKey: string): Promise<void> {
+    // Vorhandene Sitzung stoppen
+    if (this.pc) {
+      this.stopSession();
     }
-    const url = 'wss://api.openai.com/v1/realtime?model=gpt-4o-realtime-preview';
-    this.socket = new WebSocket(url, [
-      'realtime',
-      `openai-insecure-api-key.${apiKey}`,
-      'openai-beta.realtime=v1',
-    ]);
-    this.socket.onmessage = (event) => this.handleMessage(event);
-    this.socket.onerror = (err) => console.error('Realtime session error', err);
-  }
 
-  private handleMessage(event: MessageEvent) {
-    try {
-      const message = JSON.parse(event.data);
-      if (message.type === 'form_update' && message.data) {
-        this.zone.run(() => this.formUpdatesSubject.next(message.data));
+    // PeerConnection erstellen
+    this.pc = new RTCPeerConnection();
+
+    // Audioelement für Remote-Audio vorbereiten
+    this.audioEl = document.createElement('audio');
+    this.audioEl.autoplay = true;
+    this.pc.ontrack = (event) => {
+      // Eingehende Audiospuren auf dem Audioelement abspielen
+      if (this.audioEl) {
+        this.audioEl.srcObject = event.streams[0];
       }
-    } catch (error) {
-      console.error('Failed to handle message', error);
-    }
+    };
+
+    // Mikrofonzugriff anfordern und Spur hinzufügen
+    this.ms = await navigator.mediaDevices.getUserMedia({ audio: true });
+    this.pc.addTrack(this.ms.getTracks()[0]);
+
+    // Datenkanal für Events einrichten
+    this.dc = this.pc.createDataChannel('oai-events');
+    this.dc.addEventListener('message', (e) => {
+      console.log('Realtime server event', e);
+      try {
+        const message = JSON.parse(e.data);
+        if (message.type === 'form_update' && message.data) {
+          this.zone.run(() => this.formUpdatesSubject.next(message.data));
+        }
+      } catch {
+        // Ignoriere fehlerhafte Nachrichten
+      }
+    });
+
+    // SDP-Angebot erstellen und an den Realtime-Server senden
+    const offer = await this.pc.createOffer();
+    await this.pc.setLocalDescription(offer);
+
+    const sdpResponse = await fetch(`${this.baseUrl}?model=${this.model}`, {
+      method: 'POST',
+      body: offer.sdp,
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/sdp',
+      },
+    });
+
+    // Antwort des Servers setzen, um Verbindung zu vervollständigen
+    const answer = { type: 'answer', sdp: await sdpResponse.text() };
+    await this.pc.setRemoteDescription(answer as RTCSessionDescriptionInit);
   }
 
+  /**
+   * Beendet die aktive Realtime-Sitzung und gibt Ressourcen frei.
+   */
   stopSession(): void {
-    console.log('Realtime session stopped');
+    this.dc?.close();
+    this.pc?.close();
+    this.ms?.getTracks().forEach((t) => t.stop());
+    this.dc = undefined;
+    this.pc = undefined;
+    this.ms = undefined;
   }
 }
+


### PR DESCRIPTION
## Summary
- replace websocket-based realtime service with WebRTC implementation
- add audio playback, microphone capture and event data channel
- handle server answers and cleanly close sessions

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b3255b01dc8327a639977576886027